### PR TITLE
Fix link for posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'http://rubygems.org'
 
 gem 'jekyll'
+gem 'rdiscount'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     pygments.rb (0.5.2)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
+    rdiscount (2.1.6)
     safe_yaml (0.7.1)
     syntax (1.0.0)
     yajl-ruby (1.1.0)
@@ -36,3 +37,4 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  rdiscount

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,31 +8,31 @@
     <meta name="author" content="## 著作者 ##">
     <meta http-equiv="X-UA-Compatible" content="IE=9"/>
     <title>{{ page.title }} - {{ site.name }}</title>
-    <link href="{{ page.root }}bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
-    <link href="{{ page.root }}css/main.css" rel="stylesheet" media="screen">
+    <link href="{{ page.root }}/bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
+    <link href="{{ page.root }}/css/main.css" rel="stylesheet" media="screen">
 </head>
 <body>
 <div class="container">
-    <a href="{{ page.root }}">
-        <img class="logo" src="{{ page.root }}img/scalajp_logo.png" alt="日本Scala ユーザーグループロゴ(ScalaJP)">
+    <a href="{{ page.root }}/">
+        <img class="logo" src="{{ page.root }}/img/scalajp_logo.png" alt="日本Scala ユーザーグループロゴ(ScalaJP)">
     </a>
 
     <div class="row">
         <div class="span3">
             <ul class="nav nav-list">
-                <li><a href="{{ page.root }}news.html">ニュース(アーカイブ)</a>
+                <li><a href="{{ page.root }}/news.html">ニュース(アーカイブ)</a>
                 </li>
-                <li><a href="{{ page.root }}communities.html">コミュニティとイベント</a></li>
-                <li><a href="{{ page.root }}articles.html">技術記事</a></li>
-                <li><a href="{{ page.root }}books.html">書籍</a></li>
-                <li><a href="{{ page.root }}links.html">Scala関係リンク集</a></li>
+                <li><a href="{{ page.root }}/communities.html">コミュニティとイベント</a></li>
+                <li><a href="{{ page.root }}/articles.html">技術記事</a></li>
+                <li><a href="{{ page.root }}/books.html">書籍</a></li>
+                <li><a href="{{ page.root }}/links.html">Scala関係リンク集</a></li>
                 <li><a href="https://github.com/scalajp/scalajp.github.com/wiki">ScalaJPウィキ</a></li>
                 <li class="nav-header">採用事例</li>
-                <li><a href="{{ page.root }}scala-cases-in-japan.html">国内事例</a></li>
-                <li><a href="{{ page.root }}scala-cases-overseas.html">海外事例</a></li>
+                <li><a href="{{ page.root }}/scala-cases-in-japan.html">国内事例</a></li>
+                <li><a href="{{ page.root }}/scala-cases-overseas.html">海外事例</a></li>
                 <li class="divider"></li>
-                <li><a href="{{ page.root }}supporters.html">協賛</a></li>
-                <li><a href="{{ page.root }}about-us.html">私たちについて</a></li>
+                <li><a href="{{ page.root }}/supporters.html">協賛</a></li>
+                <li><a href="{{ page.root }}/about-us.html">私たちについて</a></li>
             </ul>
         </div>
         <div class="span9">
@@ -44,5 +44,5 @@
     <address>Copyright&copy; Japan Scala Users Group All Rights Reserved.</address>
 </footer>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-<script src="{{ page.root }}bootstrap/js/bootstrap.min.js"></script>
+<script src="{{ page.root }}/bootstrap/js/bootstrap.min.js"></script>
 </body>

--- a/_posts/2012-02-11-scala-ide-roadmap.md
+++ b/_posts/2012-02-11-scala-ide-roadmap.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala IDE for Eclipseのロードマップ
 ---
 

--- a/_posts/2012-02-12-lift-2.4.md
+++ b/_posts/2012-02-12-lift-2.4.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Lift 2.4がリリースされました
 ---
 

--- a/_posts/2012-02-12-maven-central.md
+++ b/_posts/2012-02-12-maven-central.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: ScalaアーティファクトがMavenセントラルリポジトリに – Scala-toolsは引退
 ---
 

--- a/_posts/2012-02-22-scala-days-2012.md
+++ b/_posts/2012-02-22-scala-days-2012.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala Days 2012 – シェイプアップ!
 ---
 

--- a/_posts/2012-03-03-scala-2.10.0milestone2.md
+++ b/_posts/2012-03-03-scala-2.10.0milestone2.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン2
 ---
 

--- a/_posts/2012-03-03-scala-2.9.1-1rc1.md
+++ b/_posts/2012-03-03-scala-2.9.1-1rc1.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.1-1 RC1
 ---
 

--- a/_posts/2012-03-05-scala-2.9.1-1.md
+++ b/_posts/2012-03-05-scala-2.9.1-1.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.1-1
 ---
 

--- a/_posts/2012-03-09-scala-days-2012.md
+++ b/_posts/2012-03-09-scala-days-2012.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala Days 2012 発表者と講演
 ---
 

--- a/_posts/2012-03-11-akka-20.md
+++ b/_posts/2012-03-11-akka-20.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Akka 2.0リリース!
 ---
 

--- a/_posts/2012-03-16-typesafe-stack-20.md
+++ b/_posts/2012-03-16-typesafe-stack-20.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Typesafe Stack 2.0がリリースされました
 ---
 

--- a/_posts/2012-03-21-summer-of-code.md
+++ b/_posts/2012-03-21-summer-of-code.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scalaで取り組むSummer of Code 2012
 ---
 

--- a/_posts/2012-03-22-scala-2.9.2rc1.md
+++ b/_posts/2012-03-22-scala-2.9.2rc1.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.2 RC1
 ---
 

--- a/_posts/2012-04-01-scala-2.9.2rc2.md
+++ b/_posts/2012-04-01-scala-2.9.2rc2.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.2 RC2
 ---
 

--- a/_posts/2012-04-01-scala-ide.md
+++ b/_posts/2012-04-01-scala-ide.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala IDE 2.0.1 RC2が出ました
 ---
 

--- a/_posts/2012-04-06-scala-2.9.2rc3.md
+++ b/_posts/2012-04-06-scala-2.9.2rc3.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.2 RC3
 ---
 

--- a/_posts/2012-04-14-scala-2.9.2-final.md
+++ b/_posts/2012-04-14-scala-2.9.2-final.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.2 final
 ---
 

--- a/_posts/2012-04-14-scala-ide.md
+++ b/_posts/2012-04-14-scala-ide.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala IDE 2.1 マイルストーン1が使えるようになりました!
 ---
 

--- a/_posts/2012-05-02-scala-2.10.0milestone3.md
+++ b/_posts/2012-05-02-scala-2.10.0milestone3.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン3
 ---
 

--- a/_posts/2012-05-11-scala-ide.md
+++ b/_posts/2012-05-11-scala-ide.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala IDE 2.1の2.10.0-M3用特別版が使えるようになりました!
 ---
 

--- a/_posts/2012-06-16-scala-2.10.0milestone4.md
+++ b/_posts/2012-06-16-scala-2.10.0milestone4.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン4
 ---
 

--- a/_posts/2012-06-23-scala-ide.md
+++ b/_posts/2012-06-23-scala-ide.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala IDE for Eclipseの新しいリリース
 ---
 

--- a/_posts/2012-07-15-scala-2.10.0milestone5.md
+++ b/_posts/2012-07-15-scala-2.10.0milestone5.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン5
 ---
 

--- a/_posts/2012-08-02-scala-2.10.0milestone6.md
+++ b/_posts/2012-08-02-scala-2.10.0milestone6.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン6
 ---
 

--- a/_posts/2012-09-02-scala-2.10.0milestone7.md
+++ b/_posts/2012-09-02-scala-2.10.0milestone7.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 マイルストーン7
 ---
 

--- a/_posts/2012-11-09-scala-2.10.0rc1.md
+++ b/_posts/2012-11-09-scala-2.10.0rc1.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 RC1
 ---
 

--- a/_posts/2012-11-10-scala-2.10.0rc2.md
+++ b/_posts/2012-11-10-scala-2.10.0rc2.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 RC2
 ---
 

--- a/_posts/2012-12-14-scala-2.10.0rc5.md
+++ b/_posts/2012-12-14-scala-2.10.0rc5.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.10.0 RC5
 ---
 

--- a/_posts/2013-01-14-scala-2.9.3rc1.md
+++ b/_posts/2013-01-14-scala-2.9.3rc1.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-root: ../../../
+root: ../../..
 title: Scala 2.9.3 RC1
 ---
 

--- a/about-us.md
+++ b/about-us.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 私たちについて
 ---
 

--- a/articles.md
+++ b/articles.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 技術記事
 ---
 

--- a/books.md
+++ b/books.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 書籍
 ---
 

--- a/communities.md
+++ b/communities.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: コミュニティとイベント
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 日本Scalaユーザーズグループ
 ---
 
@@ -17,4 +17,4 @@ title: 日本Scalaユーザーズグループ
     {% endfor %}
 </div>
 
-#### [過去の記事を読む]({{ page.root }}news.html)
+#### [過去の記事を読む]({{ page.root }}/news.html)

--- a/links.md
+++ b/links.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: Scala関係リンク集
 ---
 

--- a/news.md
+++ b/news.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: ニュース(アーカイブ)
 ---
 

--- a/scala-cases-in-japan.md
+++ b/scala-cases-in-japan.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 採用事例(国内)
 ---
 

--- a/scala-cases-overseas.md
+++ b/scala-cases-overseas.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 採用事例(海外)
 ---
 

--- a/supporters.md
+++ b/supporters.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-root: ./
+root: .
 title: 協賛
 ---
 


### PR DESCRIPTION
Removed trailing slash from root in FrontMatter.

`_posts/` ページヘのリンクで `/` が２つ重なる問題を解消しました。

また Markdown processor として `rdiscount` を使用しているので、Gemfile を変更しています。 `rdiscount` を利用している理由はデフォルトの `maruku` ではリストのフォーマットが変になることがあったからです。
