### PR TITLE
Added CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+jp.scala-users.org


### PR DESCRIPTION
I suppose CNAME file is necessary to use custom domain for github pages.

ref.
https://help.github.com/articles/setting-up-a-custom-domain-with-pages
http://stackoverflow.com/questions/9082499/custom-domain-for-github-project-pages

私の環境では DNS の変更が見えていますが、404になっています。

![2013-07-30 10 32 13 pm](https://f.cloud.github.com/assets/22657/878865/7a136446-f91c-11e2-83c4-6b42bf068baf.png)
