### PR TITLE
ライセンス表記を追記

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,6 +46,7 @@
 </div>
 <footer class="footer">
     <address>Copyright&copy; Japan Scala Users Group All Rights Reserved.</address>
+    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />この <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" rel="dct:type">Webサイト</span> は <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンスの下に提供されています。</a>
 </footer>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="{{ page.root }}/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
ScalaJPのWebサイトにある情報を利用したいという問い合わせがあったのを受けて、そもそもライセンスを明記するべきでは？と思い追加してみました。
CreativeCommons表示4.0国際（要出典、改変可、商用利用可）ライセンスでいかがでしょう？
